### PR TITLE
Add ability to configure status spinner

### DIFF
--- a/src/shelloracle/config.py
+++ b/src/shelloracle/config.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from collections.abc import Mapping, Iterator
 from pathlib import Path
 from typing import Any
+from yaspin.spinners import SPINNERS_DATA
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
 
+logger = logging.getLogger(__name__)
 shelloracle_home = Path.home() / ".shelloracle"
 
 
@@ -41,6 +44,16 @@ class Configuration(Mapping):
     @property
     def provider(self) -> str:
         return self["shelloracle"]["provider"]
+
+    @property
+    def spinner_style(self) -> str | None:
+        style = self["shelloracle"].get("spinner_style", None)
+        if not style:
+            return None
+        if style not in SPINNERS_DATA:
+            logger.warning("invalid spinner style: %s", style)
+            return None
+        return style
 
 
 _config: Configuration | None = None

--- a/tests/test_shelloracle.py
+++ b/tests/test_shelloracle.py
@@ -1,9 +1,29 @@
 import os
 import sys
+from unittest.mock import MagicMock, call
 
 import pytest
+from yaspin.spinners import Spinners
 
-from shelloracle.shelloracle import get_query_from_pipe
+from shelloracle.config import Configuration
+from shelloracle.shelloracle import get_query_from_pipe, spinner
+
+
+def test_spinner(monkeypatch):
+    yaspin_mock = MagicMock()
+    monkeypatch.setattr("shelloracle.shelloracle.yaspin", yaspin_mock)
+
+    monkeypatch.setattr(Configuration, "spinner_style", None)
+    spinner()
+    assert yaspin_mock.call_args == call()
+
+    monkeypatch.setattr(Configuration, "spinner_style", "earth")
+    spinner()
+    assert yaspin_mock.call_args == call(Spinners.earth)
+
+    monkeypatch.setattr(Configuration, "spinner_style", "not a real spinner")
+    with pytest.raises(AttributeError):
+        spinner()
 
 
 def test_get_query_from_pipe(monkeypatch):

--- a/tests/test_shelloracle.py
+++ b/tests/test_shelloracle.py
@@ -1,27 +1,42 @@
+from __future__ import annotations
+
 import os
 import sys
+from dataclasses import dataclass
 from unittest.mock import MagicMock, call
 
 import pytest
 from yaspin.spinners import Spinners
 
-from shelloracle.config import Configuration
 from shelloracle.shelloracle import get_query_from_pipe, spinner
 
 
-def test_spinner(monkeypatch):
+@dataclass
+class MockConfig:
+    provider: str
+    spinner_style: str | None
+
+
+@pytest.fixture
+def set_config(monkeypatch):
+    def setter(config):
+        return monkeypatch.setattr("shelloracle.config._config", config)
+    return setter
+
+
+def test_spinner(monkeypatch, set_config):
     yaspin_mock = MagicMock()
     monkeypatch.setattr("shelloracle.shelloracle.yaspin", yaspin_mock)
 
-    monkeypatch.setattr(Configuration, "spinner_style", None)
+    set_config(MockConfig(provider="Ollama", spinner_style=None))
     spinner()
     assert yaspin_mock.call_args == call()
 
-    monkeypatch.setattr(Configuration, "spinner_style", "earth")
+    set_config(MockConfig(provider="Ollama", spinner_style="earth"))
     spinner()
     assert yaspin_mock.call_args == call(Spinners.earth)
 
-    monkeypatch.setattr(Configuration, "spinner_style", "not a real spinner")
+    set_config(MockConfig(provider="Ollama", spinner_style="not a real spinner"))
     with pytest.raises(AttributeError):
         spinner()
 


### PR DESCRIPTION
Add `spinner_style = "earth"` under the `[shelloracle]` tag of your `~/.shelloracle/config.toml` file