### PR TITLE
Improve cli cold-start speed

### DIFF
--- a/src/shelloracle/shelloracle.py
+++ b/src/shelloracle/shelloracle.py
@@ -71,13 +71,13 @@ async def shelloracle() -> None:
     :returns: None
     :raises KeyboardInterrupt: if the user presses CTRL+C
     """
-    config = get_config()
-    provider = get_provider(config.provider)()
-
     if not (prompt := get_query_from_pipe()):
         default_prompt = os.environ.get("SHOR_DEFAULT_PROMPT")
         prompt = await prompt_user(default_prompt)
     logger.info("user prompt: %s", prompt)
+
+    config = get_config()
+    provider = get_provider(config.provider)()
 
     shell_command = ""
     with create_app_session_from_tty(), patch_stdout(raw=True), spinner() as sp:


### PR DESCRIPTION
Don't access the providers until after the prompt is up to make the cli feel more responsive.

6x speed up

Closes #72 

## Before
<img width="799" alt="Screenshot 2024-09-01 at 12 19 16 AM" src="https://github.com/user-attachments/assets/7760ff32-1c67-45ae-8c00-b4096e91e7b4">

## After
<img width="815" alt="Screenshot 2024-09-01 at 12 19 01 AM" src="https://github.com/user-attachments/assets/9a2ab550-1496-49c7-b85a-4eb641972135">
